### PR TITLE
Align Antora content with v0.1 build manual

### DIFF
--- a/modules/ROOT/pages/appendix.adoc
+++ b/modules/ROOT/pages/appendix.adoc
@@ -1,22 +1,32 @@
 = Appendix
 
-== Technical References
+== Upgrade path (Section 8)
 
-=== Standards and Codes
-* Applicable electrical codes
-* Safety standards
-* Materials specifications
+* Deploy an inert ceramic-metal anode to eliminate residual carbon contact.
+* Expand the MOE pot with dual-zone heaters for higher throughput.
+* Upgrade spectrometers for deeper UV coverage to resolve trace boron/phosphorus.
+* Automate tapping and ladle handling, integrating spectral feedback for closed-loop recipe tuning.
 
-=== Supplier Information
-* Recommended component suppliers
-* Contact information
-* Part numbers and specifications
+== Target setpoints (Appendix A)
 
-=== Additional Resources
-* Further reading
-* Related projects
-* Community forums
+* MOE hot-zone: **1625 °C** nominal.
+* Fe stage: current density **0.2–0.4 A cm⁻²**, tuned via OES.
+* Si stage: increase potential by **10–20 %** compared to the Fe stage, watching silicon emission and headspace oxygen.
+* Vacuum refining: **1700–1800 °C**, **≤10 Pa**, **30–90 min** hold.
 
-== Coming Soon
+== Minimal tools (Appendix B)
 
-Additional reference materials will be added in future revisions of this guide.
+* IR thermometer for quick checks.
+* Torque drivers, crimp kits, and electrical hand tools.
+* TIG-grade gloves, tongs, face shield, and PPE described in the safety chapter.
+* Precision scale and sieve set for feed preparation.
+
+== Expected consumables per 10 runs (Appendix C)
+
+* Argon: ≤1 m³ with reclaim.
+* Liners: 1 primary ZrO₂ liner plus 1 Al₂O₃ backup.
+* Anode face or coating: replace as needed if consumable.
+
+== Cost recap
+
+The v0.1 build lands at **\$8.8–9.8k** when leveraging surplus procurement strategies detailed in xref:materials.adoc[Materials & Components]. Track actual expenses to refine future revisions of the manual.

--- a/modules/ROOT/pages/chamber-construction.adoc
+++ b/modules/ROOT/pages/chamber-construction.adoc
@@ -1,20 +1,28 @@
 = Chamber Construction
 
-== Overview
+== Frame & insulation (Step 3.1)
 
-This chapter covers the detailed construction of the electrolysis chamber, including fabrication techniques, assembly procedures, and quality control measures.
+. Build a rigid frame from 80/20 extrusion or welded angle steel with an interior clear volume of roughly 200 mm Ø × 250 mm H to house the liner stack.
+. Line the enclosure with 1700 °C-rated fiber boards, then add blanket layers to minimize heat leak. Install reflective shields (Mo or W foil) on standoffs to redirect radiant heat.
+. Cut and seal service penetrations for the feeder, viewport, pyrometer peeks, electrode feedthroughs, and gas ports. Keep every leak path short and sleeve openings with ceramic bushings.
+. Install removable access panels with captive hardware so inspection and maintenance can happen without disturbing insulation integrity.
 
-== Coming Soon
+== Heater & hot-zone integration (Step 3.2)
 
-Detailed construction instructions will be added in future revisions of this guide.
+. **MoSi₂ element option:** Arrange three to four elements evenly around the liner, following vendor spacing guidance. Wire them through SSRs or transformer taps, maintain sight lines to the melt, and protect leads from radiant heat.
+. **Induction option:** Wind a water-cooled copper coil around the liner zone with adequate electrical isolation. Mount the 3–5 kW driver near the coil, bond the shielding, and verify coolant flow before high-power operation.
+. Seat the primary **ZrO₂** liner inside a structural setter. Position the **W** cathode tip 10–20 mm above the floor sump and mount the anode opposite the wall (prefer an inert anode or shielded graphite to minimize carbon exposure).
+. Route thermocouple or pyrometer sight tubes through purged ports to capture wall and melt temperatures without fogging.
 
-== Placeholder Content
+== Phase separation geometry (Step 3.3)
 
-* Detailed fabrication drawings
-* Step-by-step assembly instructions
-* Quality control checkpoints
-* Testing procedures
+. Fit a weir that lets light slag overflow into a dedicated slag pocket while dense iron collects in a deep sump under the cathode.
+. Machine a silicon collection pocket isolated from the iron sump with a raised sill. The geometry should encourage silicon to settle away from slag before transfer.
+. Plan for a tilting ladle or tap hole that can draw silicon into a covered transfer crucible without disturbing the iron sump.
+. Dry fit all inserts at room temperature, confirm clearances, and mark alignment features so high-temperature assembly is repeatable.
 
-== Next Steps
+== Pre-flight checks
 
-Proceed to xref:electrical-system.adoc[Electrical System] when chamber construction is complete.
+* Verify liner contact surfaces are clean and that all ceramic components are free of cracks before heat-up.
+* Confirm electrode standoffs and feedthrough seals maintain electrical isolation at temperature.
+* Document final dimensions and orientations for reference in maintenance and troubleshooting chapters.

--- a/modules/ROOT/pages/control-system.adoc
+++ b/modules/ROOT/pages/control-system.adoc
@@ -1,13 +1,30 @@
 = Control System
 
-== Overview
+== Hardware integration (Step 3.6)
 
-This chapter covers the control system design, programming, and configuration for automated MOERC operation.
+. Install the PLC or compact industrial controller along with IO modules, SSRs/contactors, and hardwired interlocks. Map door, panel, over-temperature, and vacuum-OK signals before energizing heaters.
+. Mount two-color pyrometers with purged sight tubes aimed at the melt zone and refining pot. Verify both channels read correctly from room temperature through a controlled heat soak.
+. Position the **LIBS** head above the feed inlet or melt surface using a windowed port. Route the fiber bundle to the gated spectrometer and perform alignment shots on inert targets before live material.
+. Aim the **OES** fiber toward the electrode/plasma zone to resolve Fe, Si, and O emission lines. Confirm shielding prevents stray light or arc flash from saturating the detector.
+. Connect the **RGA** to the refining foreline via a throttled tee downstream of the cold-trap. Calibrate mass peaks during a dry pump-down to establish baselines.
 
-== Coming Soon
+== Software & interlocks
 
-Detailed control system instructions will be added in future revisions of this guide.
+* Implement permissives that block heater enable until all door, panel, vacuum, and coolant interlocks report safe states.
+* Use PID loops for heater zones with ramps/soaks tailored to the target temperatures in each process stage.
+* Log critical parameters (temperatures, currents, spectra, pressures) at intervals sufficient for later analysis and troubleshooting.
 
-== Next Steps
+== Control logic (Section 5)
 
-Proceed to xref:testing.adoc[Testing & Calibration] when control system is complete.
+. Preheat the MOE cell to 1600 °C and hold for 20 min to stabilize the thermal mass.
+. Verify LIBS feed characterization meets recipe limits; abort if out of bounds.
+. Enter the **Fe window**: apply low cathodic overpotential/current density and watch OES lines until the iron sump mass threshold is met. Tap or park the iron as required.
+. Transition to the **Si window**: increase potential by 10–20 % compared to the Fe stage, monitor silicon emission growth, and manage the headspace to keep Fe isolated.
+. Transfer molten silicon to the refining pot. Initiate vacuum refining once ≤10 Pa is reached and continue until the RGA shows phosphorous species below threshold.
+. Command the casting sequence, cool under control, and record spectra/logs for post-run review.
+
+== Commissioning tests
+
+* Dry-run the full control sequence without feed to validate interlocks, sensor scaling, and data logging.
+* Inject known spectral lines (calibration lamps or reference targets) to confirm LIBS/OES wavelength accuracy before production runs.
+* Simulate an emergency stop to confirm all heaters and motion drives default to safe states while maintaining data capture.

--- a/modules/ROOT/pages/electrical-system.adoc
+++ b/modules/ROOT/pages/electrical-system.adoc
@@ -1,20 +1,28 @@
-= Electrical System
+= Electrical System & Utilities
 
-== Overview
+== Vacuum refining vessel (Step 3.4)
 
-This chapter covers the electrical system design, installation, and testing procedures for the MOERC power and control systems.
+. Assemble the stainless vacuum can with internal crucible supports and the selected heater package (MoSi₂ elements or induction coil). Ensure all feedthroughs are water-cooled and rated for 1600–1900 °C operation.
+. Install the cold-trap on the exhaust path. Use a water-cooled finger plus a removable cryogenic cup to capture SiO and P species before they reach the pump.
+. Route the chamber outlet through an isolation valve to the pump manifold. Tee in both a Pirani gauge and a capacitance manometer so you can monitor across the full pressure range.
+. Verify that all seals seat properly under vacuum and that thermocouple or pyrometer sight ports maintain line-of-sight without fouling.
 
-== Coming Soon
+== Gas & vacuum skid (Step 3.5)
 
-Detailed electrical system instructions will be added in future revisions of this guide.
+. Mount the rotary vane pump on vibration pads and plumb a KF manifold that can independently service the MOE cell and the refining pot. Include check valves to prevent back-streaming.
+. Build the argon loop: buffer tank → dryer → 0.1 µm filter → mass-flow control → process inlet. Return gas through a filter to the buffer tank to enable reclaim.
+. Provide an oxygen vent line from the MOE headspace to an exterior safe vent or capture bottle. Install throttling so the process headspace maintains 50–150 mbar above ambient during operation.
+. Add quick-service ports for leak checks and purge operations. Label every valve position and document the normal operating configuration.
 
-== Placeholder Content
+== Power distribution & grounding (Step 3.7)
 
-* Electrical schematics and wiring diagrams
-* Component installation procedures
-* System testing and commissioning
-* Safety verification procedures
+. Route 120 V mains through a line conditioner, UPS, or portable power station rated for ≥1.8 kW continuous output. This buffer rides through brownouts and keeps control power stable.
+. Split clean control power from heater feeds. Use appropriately sized breakers, contactors, and solid-state relays to switch the heating loads. Bond all metallic enclosures and maintain a single-point ground.
+. Install a dedicated emergency stop that drops heater power and signals the control system to transition to a safe state.
+. Confirm wire gauges, lug ratings, and insulation class match the expected current draw and ambient temperature.
 
-== Next Steps
+== Commissioning checks
 
-Proceed to xref:control-system.adoc[Control System] when electrical installation is complete.
+* Perform a megger or insulation resistance test on heater circuits before first heat.
+* Leak-check the vacuum manifold with argon at 50 mbar over ambient; target <50 sccm leakage before proceeding.
+* Simulate a power-loss event to confirm the UPS/inverter maintains controls while heaters coast down safely.

--- a/modules/ROOT/pages/maintenance.adoc
+++ b/modules/ROOT/pages/maintenance.adoc
@@ -1,13 +1,25 @@
 = Maintenance
 
-== Overview
+== Routine schedule (Section 7)
 
-This chapter covers preventive maintenance schedules, procedures, and spare parts management.
+* Inspect liners and electrodes after every ~10 hours at temperature. Replace worn anode faces and document cathode recession.
+* Bake the argon dryer and replace filters quarterly or when differential pressure rises beyond spec.
+* Clean cold traps after each run; capture and store condensed SiO for potential reclaim or proper disposal.
+* Calibrate pyrometers quarterly and verify LIBS/OES wavelength alignment during each daily warm-up cycle.
 
-== Coming Soon
+== Post-run service
 
-Detailed maintenance procedures will be added in future revisions of this guide.
+. Allow the system to cool below 200 °C before opening.
+. Remove slag and residual metal from the phase-separation pockets. Check for erosion or cracks and replace inserts if necessary.
+. Inspect vacuum seals, pump oil, and scroll tips. Top off or service pumps according to manufacturer recommendations.
+. Empty and regenerate desiccant beds in the argon dryer if moisture breakthrough is detected.
 
-== Next Steps
+== Spares & consumables
 
-Proceed to xref:appendix.adoc[Appendix] for additional reference materials.
+* Maintain at least one spare ZrO₂ liner and an Al₂O₃ backup set.
+* Stock replacement electrodes or coatings (IrO₂) to avoid downtime.
+* Keep desiccant cartridges, filters, and cold-trap cups in rotation so cleaning cycles do not halt production.
+
+== Record keeping
+
+Log maintenance actions alongside batch data. Tracking liner hours, electrode wear, and pump service intervals is essential for correlating yield changes with hardware condition.

--- a/modules/ROOT/pages/materials.adoc
+++ b/modules/ROOT/pages/materials.adoc
@@ -1,90 +1,56 @@
 = Materials & Components
 
-== Required Materials
+== Bill of materials (indicative, USD)
 
-This section lists all materials and components needed to construct the MOERC. Items are organized by subsystem for easier procurement and organization.
+_Prices match the v0.1 manual and assume new commercial hardware unless noted. Substitute equivalent or surplus parts where available._
 
-=== Chamber Construction
+=== Hot-zone & MOE cell (~$3,150)
 
-==== Structural Components
-* Stainless steel chamber body (316L grade recommended)
-* High-temperature gaskets and seals
-* Insulation materials (ceramic fiber blanket)
-* Viewing ports (borosilicate glass)
+* High-temperature insulation kit (1700 °C fiber boards/blanket, panels, fasteners) — **$350**
+* Modular steel frame (80/20 extrusion or welded assembly) with panels and hardware — **$250**
+* Crucible set: primary **ZrO₂** liner (1.5–2 L) plus two **Al₂O₃** backups — **$400**
+* Refractory-metal electrodes: **W** cathode set with **Mo** spares and an optional **IrO₂** inert anode — **$900**
+* Heater package: **MoSi₂** elements (1700 °C rating) with holders _or_ induction coil + 3–5 kW driver (120 V input) — **$950**
+* Thermography: dual two-color pyrometers covering 600–2000 °C — **$300**
+* Fixtures: ceramic feed port, UV-grade fused silica viewports, fast-shut baffles — **$150**
 
-==== Fasteners and Hardware
-* High-temperature bolts and nuts (A286 stainless steel)
-* Washers and spacers
-* Threaded rods and mounting brackets
+=== Vacuum refining vessel (~$1,750)
 
-=== Electrical System
+* Small high-vacuum furnace can (stainless shell, water-cooled feedthroughs) — **$600**
+* Heater insert (MoSi₂ elements or induction coil) — **$450**
+* Cold-trap assembly (water-cooled finger plus removable cryo cup) — **$250**
+* Vacuum hardware set: KF25/KF40 fittings, valves, and gauges (Pirani + capacitance manometer) — **$300**
+* Silicon crucible for refining (graphite or high-density SiC that avoids direct silica contact) — **$150**
 
-==== Power Supply
-* DC power supply (0-50V, 0-500A) with current regulation
-* Power cables (high-current, insulated)
-* Safety disconnect switches
-* Circuit breakers and fuses
+=== Gas & vacuum (~$1,600)
 
-==== Electrodes
-* Graphite anodes (high-purity grade)
-* Copper cathodes (99.9% pure)
-* Electrode holders and insulators
-* Connection hardware
+* Rotary vane pump (5–8 m³ h⁻¹) with backing filter — **$700**
+* Dry scroll pump (used or small new) as an optional upgrade — **$700**
+* Argon loop components: 20–40 L buffer tank, 0.1 µm filter, desiccant dryer — **$200**
 
-=== Control System
+=== Feed handling & casting (~$900)
 
-==== Sensors
-* Type K thermocouples (high-temperature rated)
-* Current shunts for amperage monitoring
-* Voltage monitoring circuits
-* Pressure sensors (if applicable)
+* Hopper with vacuum-tolerant auger (stainless screw, NEMA 17/23 stepper, driver) — **$300**
+* Inline dryer with 500 W cartridge heater and PID controller (150–250 °C) — **$150**
+* Screening kit: 250 µm and 100 µm meshes plus a benchtop jaw crusher — **$250**
+* Directional solidification station: Si₃N₄-coated quartz crucibles (2–3), mold base, slow-cool plate — **$200**
 
-==== Control Electronics
-* Programmable logic controller (PLC) or microcontroller
-* Solid-state relays
-* Display panels
-* Emergency stop buttons
+=== Controls & sensing (~$1,900)
 
-=== Safety Equipment
+* PLC or compact industrial controller with IO modules, SSRs/contactors, and E-stop — **$600**
+* **LIBS** head (OEM pulsed laser + gated spectrometer, 200–900 nm) — **$800**
+* **OES** spectrometer (300–900 nm) with optics and fiber — **$250**
+* **RGA** (bench quadrupole, 1–100 amu, used/refurbished) — **$250**
 
-==== Personal Protective Equipment
-* Safety glasses with side shields
-* Heat-resistant gloves
-* Chemical-resistant aprons
-* Respiratory protection (if handling chemicals)
+=== Power & energy (~$1,500)
 
-==== Ventilation
-* Exhaust fans
-* Ductwork and fittings
-* Gas scrubbing system (if required)
+* 120 V line conditioner/UPS or portable power station (≥1.8 kW continuous, ~1.5 kWh) — **$1,000**
+* Power distribution unit, breakers, cabling, GFCI, and grounding hardware — **$300**
+* Optional 400–600 W PV input cabling for recharging the storage pack — **$200**
 
-== Tools Required
+== Budget guidance
 
-=== Metalworking Tools
-* TIG welding equipment
-* Angle grinder
-* Drill press
-* Precision measuring tools
+* **Subtotal (new parts):** ~\$10,800
+* **Targeted v0.1 build cost:** \$8.8k–9.8k when leveraging surplus UPS/pumps/spectrometers (–\$800 to –\$1,500), choosing resistance heaters over induction (–\$300), limiting to a single pyrometer (–\$150), and fabricating the frame in-house (–\$200).
 
-=== Electrical Tools
-* Multimeter
-* Wire strippers and crimpers
-* Soldering equipment
-* Electrical testing equipment
-
-== Procurement Guidelines
-
-=== Sourcing Recommendations
-* Purchase electrical components from certified suppliers
-* Verify material certifications for high-temperature components
-* Consider lead times for specialized items
-* Maintain documentation for all components
-
-=== Cost Estimation
-* Budget approximately $5,000-$8,000 for complete system
-* Costs may vary based on specifications and local suppliers
-* Consider used equipment for non-critical components
-
-== Next Steps
-
-With materials identified, proceed to xref:safety.adoc[Safety Guidelines] before beginning construction.
+Document every substitution so operating parameters can be adjusted accordingly. Consumables and tool requirements are summarized in the xref:appendix.adoc[Appendix].

--- a/modules/ROOT/pages/operation.adoc
+++ b/modules/ROOT/pages/operation.adoc
@@ -1,13 +1,27 @@
 = Operation Manual
 
-== Overview
+== MOE operation (Section 4.3)
 
-This chapter covers normal operation procedures, process parameters, and operational best practices.
+. Bring the hot zone to 1600–1650 °C under a light argon blanket (50–150 mbar above ambient). Confirm thermal stability before feeding.
+. Enter the **Fe stage** with a low cathodic overpotential/current density. Monitor **OES** for iron emission lines as the metal accumulates in the sump. Tap or park iron once the sump reaches the planned mass.
+. Transition to the **Si stage** by stepping the potential upward 10–20 %. Watch silicon emission intensity and headspace oxygen signals. Keep the Fe sump slightly cooler to discourage alloying.
+. Manage bubble evolution and avoid vigorous stirring. If LIBS/OES indicates co-reduction or alloy formation, reduce potential, allow iron to settle, and resume once signals stabilize.
 
-== Coming Soon
+== Transfer to refining pot (Section 4.4)
 
-Detailed operation instructions will be added in future revisions of this guide.
+. Ladle or tap molten silicon into a covered transfer crucible to minimize air exposure.
+. Move the crucible to the refining vessel, close the chamber, evacuate to ≤10 Pa, and ramp to 1600–1850 °C.
+. Hold for 30–90 min while monitoring the **RGA**. Falling phosphorous peaks indicate progress; a rise in **SiO (m/z ~44)** signals over-evaporation—tighten cold-trap cooling or adjust temperature accordingly.
 
-== Next Steps
+== Casting (Section 4.5)
 
-Proceed to xref:troubleshooting.adoc[Troubleshooting] for problem resolution guidance.
+. Pour refined silicon into a **Si₃N₄**-coated quartz mold.
+. Directionally cool at 1–5 K min⁻¹ from bottom to top to segregate residual impurities toward the hot end.
+. Crop the tail section that concentrates impurities.
+. Optionally perform a mini float-zone pass on a small rod if semiconductor experiments are planned.
+
+== Post-run
+
+* Log temperatures, currents, vacuum levels, and spectral data for the full batch record.
+* Inspect slag pockets, iron sump, and collection pocket before cool-down completes so issues can be documented.
+* Prepare the system for cleaning per the xref:maintenance.adoc[Maintenance] chapter before starting the next batch.

--- a/modules/ROOT/pages/overview.adoc
+++ b/modules/ROOT/pages/overview.adoc
@@ -1,65 +1,47 @@
 = System Overview
 
-== Introduction
+== At-a-glance
 
-The Metal-Oxide Electrolysis Refinement Chamber (MOERC) is a precision electrolytic processing system designed for controlled metal-oxide reduction and refinement processes. This chapter provides a comprehensive overview of the system architecture, operating principles, and key components.
+* **Batch size:** ~1 kg dry SiO₂-dominant feed → ~200 g silicon learning target.
+* **Process chain:** Molten oxide electrolysis (Fe→Si→Al staging) → vacuum refining → directional solidification.
+* **Operating temperatures:** 1600–1700 °C in the MOE cell; 1600–1900 °C during vacuum refining; 1450–1550 °C for casting.
+* **Power input:** 120 V AC service with a ≥1.8 kW inverter/UPS inline to ride through sag events and isolate controls.
+* **Atmosphere management:** Argon backfill loop with reclaim, oxygen evolution venting, and cold-trapped exhaust.
+* **Footprint:** Bench-top stack, approximately 0.8 m × 0.6 m × 1.2 m for the complete module set.
 
-== System Architecture
+== System architecture
 
-The MOERC consists of several integrated subsystems:
+The v0.1 build organizes the hardware into eight cooperating modules. Work through them in order to maintain clear interfaces.
 
-=== Primary Components
+. **Feed prep & autofeed** – Hopper, auger, dryer (150–250 °C), and screening (≤250 µm) with an optional jaw crusher for raw rock.
+. **MOE cell (melter + electrolyzer)** – Insulated hot zone with ZrO₂/Al₂O₃ liners, refractory metal electrodes, and staged potentials for selective reduction.
+. **Phase separation** – Weir and sump geometry that parks iron in a deep pocket, skims slag, and directs silicon into an isolated collection pocket.
+. **Vacuum refining pot** – Dedicated vessel rated for 1600–1900 °C at ≤10 Pa with cold traps to capture SiO and phosphorous species.
+. **Ingot casting** – Directional solidification station using Si₃N₄-coated crucibles and a controlled cool-down plate.
+. **Gas & vacuum skid** – Rotary vane pump, optional dry scroll, argon buffer, dryer, filter stack, and oxygen vent/capture plumbing.
+. **Controls & sensing** – PLC or industrial micro, pyrometry, LIBS/OES for spectral feedback, residual gas analysis, and interlocks.
+. **Power & energy** – 120 V line conditioner or portable power station feeding heaters and controls with proper bonding and protection.
 
-* **Electrolysis Chamber**: The main reaction vessel where electrochemical processes occur
-* **Electrode Assembly**: Precisely positioned anodes and cathodes for optimal current distribution
-* **Power Supply System**: High-current, regulated DC power delivery
-* **Control System**: Automated monitoring and process control
-* **Safety Systems**: Multiple layers of protection and emergency shutdown capabilities
-* **Cooling System**: Thermal management for stable operation
+== Operating envelope
 
-=== Operating Principles
-
-The MOERC operates on the principle of controlled electrolysis, where electrical energy drives chemical reactions to reduce metal oxides to their pure metallic form. Key process parameters include:
-
-* Current density control
-* Temperature regulation
-* Electrolyte composition management
-* Gas management and ventilation
-
-== Performance Specifications
-
-[cols="1,2"]
+[cols="1,1",options="header"]
 |===
-|Parameter |Specification
-
-|Operating Temperature
-|200-800°C (adjustable)
-
-|Maximum Current
-|500A DC
-
-|Voltage Range
-|5-50V DC
-
-|Chamber Volume
-|2.5 liters
-
-|Process Efficiency
-|>95% theoretical
-
-|Control Accuracy
-|±1°C, ±0.1A
+|Parameter|Baseline target
+|MOE hot-zone temperature|1625 °C nominal, 1600–1700 °C acceptable
+|Vacuum refining|1700–1800 °C, ≤10 Pa, 30–90 min hold
+|Casting|1450–1550 °C pour with 1–5 K/min directional cool
+|Current density (Fe stage)|0.2–0.4 A cm^-2^, tuned via OES feedback
+|Atmosphere|Argon backfill 50–150 mbar above ambient, O₂ vented safely
+|Leak rate (argon test)|<50 sccm at 50 mbar over ambient
 |===
 
-== Applications
+== Utilities and support equipment
 
-The MOERC is suitable for:
+* **Electrical:** 120 V, 15–20 A circuit with GFCI protection, bonded grounds, and separated clean power for controls.
+* **Cooling:** Water loop for cold traps and any induction coil jackets; ensure flow monitoring before high-temperature work.
+* **Instrumentation:** Dual two-color pyrometers, LIBS head for feed characterization, OES aimed at the melt, and RGA on the refining foreline.
+* **Gas handling:** Argon reclaim loop with buffer tank, dryer, and filtration; oxygen vent line routed to a safe exhaust or capture bottle.
 
-* Educational demonstrations of electrochemical principles
-* Small-scale metal refining research
-* Process development and optimization
-* Materials science experiments
+== Workflow context
 
-== Next Steps
-
-Proceed to xref:materials.adoc[Materials & Components] to begin planning your build.
+The overview sets the stage for the detailed chapters that follow. Continue to xref:materials.adoc[Materials & Components] for the subsystem bill of materials before you start fabricating the frame.

--- a/modules/ROOT/pages/preface.adoc
+++ b/modules/ROOT/pages/preface.adoc
@@ -7,27 +7,37 @@
 
 == Preface
 
-Welcome to the Metal-Oxide Electrolysis Refinement Chamber (MOERC) Build Guide.
+Welcome to the **Metal Oxide Electrolysis Refinement Chamber (MOERC)** build guide. This edition aligns with the v0.1 field manual and captures the exact configuration used to turn approximately 1 kg of oxide feed into a 200 g learning‑grade silicon ingot using molten oxide electrolysis followed by vacuum refining and casting.
 
-This comprehensive guide provides step-by-step instructions for constructing your own Metal-Oxide Electrolysis Refinement Chamber. The MOERC is designed for educational and research purposes, demonstrating principles of electrochemistry, materials science, and precision engineering.
+=== About this release
 
-=== About This Guide
+* **Process chain:** MOE (Fe→Si→Al staging) → vacuum refining → directional casting.
+* **Power & utilities:** 120 V mains with an inline ≥1.8 kW battery/inverter for ride‑through and clean control power.
+* **Budget target:** <\$10k by combining commercial off‑the‑shelf (COTS) parts with surplus and DIY fabrication.
+* **Footprint:** Bench stack roughly 0.8 m × 0.6 m × 1.2 m for the full module set.
 
-This guide is organized as a complete build manual, taking you from initial planning through final testing and operation. Each section builds upon the previous ones, so it's recommended to read through the entire guide before beginning construction.
+The goal of this document is to reproduce that baseline as faithfully as possible so that later upgrades can be layered on with confidence.
 
-=== Safety Notice
+=== Who this guide is for
 
-IMPORTANT: This project involves high voltages, chemical processes, and precision equipment. Please read and understand all safety guidelines before beginning any work. Always use appropriate personal protective equipment and follow local safety regulations.
+This guide assumes hands‑on familiarity with fabrication, high‑temperature lab work, and industrial electrical practice. You should be comfortable welding or bolting a frame, plumbing vacuum hardware, wiring control cabinets, and validating instrumentation.
 
-=== Prerequisites
+=== How to use this manual
 
-Before starting this project, you should have:
+Each chapter corresponds to the build sequence used in the v0.1 manual:
 
-* Basic understanding of electrical circuits and safety
-* Familiarity with metalworking and fabrication techniques
-* Access to appropriate tools and workspace
-* Understanding of chemical safety procedures
+. System overview and performance envelope.
+. Bill of materials broken out by subsystem.
+. Step‑by‑step build instructions from frame to controls.
+. Commissioning, operation, and post‑run maintenance.
+. Appendices with setpoints, minimal tool lists, and consumable expectations.
+
+Read the entire manual before committing hardware. Cross‑linking between chapters mirrors the way the hardware is staged, so you can mark off sections as they are completed.
+
+=== Safety first
+
+The MOERC operates at 1600–1900 °C, emits bright thermal radiation, evolves oxygen, and draws high current from mains power. Review the dedicated xref:safety.adoc[Safety Guidelines] chapter, prepare your workspace, and stage PPE before any build or operation work begins.
 
 === License
 
-This work is licensed under CC0 1.0 Universal. You are free to use, modify, and distribute this content without restriction.
+This build guide is released under a Creative Commons **CC‑BY** license. Please attribute “MOERC Build Manual v0.1” when you reuse or remix these instructions.

--- a/modules/ROOT/pages/safety.adoc
+++ b/modules/ROOT/pages/safety.adoc
@@ -1,129 +1,39 @@
 = Safety Guidelines
 
-== Critical Safety Information
+== Hazard summary (Section 6)
 
-WARNING: The MOERC operates with high voltages, high temperatures, and potentially hazardous chemicals. Failure to follow safety procedures can result in serious injury or death.
+* **Thermal:** Process temperatures exceed 1700 °C. Maintain radiant shields, use IR-rated PPE, and keep combustible materials clear of the hot zone.
+* **Gas:** Oxygen is evolved during electrolysis. Provide positive venting away from personnel. The process is HF-free; off-gas is primarily O₂/Ar/SiO captured by cold traps.
+* **Electrical:** 120 V mains at high current. Use bonded grounds, GFCI protection, and an emergency stop that drops heater power. Ensure the UPS/inverter is sized for continuous draw.
+* **Optical:** Bright hot surfaces and potential arc light demand UV/IR eye protection when inspecting.
+* **Mechanical:** Guard moving hardware such as the auger, interlock access panels, and post hot-work signage in the lab.
 
-== General Safety Principles
+== Personal protective equipment
 
-=== Before You Begin
-* Read and understand all safety guidelines
-* Ensure proper training on all equipment and procedures
-* Have emergency contacts and procedures readily available
-* Verify that your workspace meets all safety requirements
+Always stage the following before build or operation work:
 
-=== Personal Protective Equipment (PPE)
+* Face shield and IR/UV-rated eye protection when observing the hot zone.
+* Heat-rated gloves (TIG-grade) and insulated aprons for handling hot components.
+* Respiratory protection when servicing the argon loop, cold traps, or handling fine powders.
+* Closed-toe, non-slip footwear and flame-resistant clothing.
 
-==== Always Required
-* Safety glasses with side protection
-* Heat-resistant gloves rated for temperatures up to 1000°C
-* Closed-toe shoes with non-slip soles
-* Long pants and long-sleeved shirts (natural fibers preferred)
+== Administrative controls
 
-==== When Applicable
-* Chemical-resistant aprons when handling electrolytes
-* Respiratory protection when exposure to fumes is possible
-* Face shields for high-risk operations
-* Hearing protection in noisy environments
+* Develop lockout/tagout procedures covering heaters, pumps, and control power.
+* Keep a current bill of materials, wiring diagrams, and emergency contacts posted near the workstation.
+* Train all personnel on emergency stop location, oxygen vent routing, and spill response.
+* Maintain clear walkways and segregate gas cylinders or power gear from general traffic areas.
 
-== Electrical Safety
+== Startup checklist
 
-=== High Voltage Precautions
-* Always de-energize system before maintenance
-* Use lockout/tagout procedures
-* Verify zero energy state with appropriate test equipment
-* Never work alone on electrical systems
+. Inspect liners, electrodes, and insulation for cracks or contamination.
+. Verify argon flow, oxygen vent routing, and that the cold-trap coolant loop is primed.
+. Test interlocks and emergency stops prior to heating.
+. Confirm PPE availability and that observers understand stay-out zones.
 
-=== Grounding and Bonding
-* Ensure all equipment is properly grounded
-* Verify ground fault protection is installed and functional
-* Use GFCI-protected outlets where applicable
-* Maintain proper equipment grounding throughout operation
+== Shutdown checklist
 
-== Thermal Safety
-
-=== High Temperature Hazards
-* Allow adequate cooling time before maintenance
-* Use appropriate thermal barriers and insulation
-* Monitor surface temperatures of accessible components
-* Provide clear warning labels on hot surfaces
-
-=== Thermal Protection Systems
-* Install thermal overload protection
-* Implement temperature monitoring and alarms
-* Ensure adequate ventilation for heat dissipation
-* Maintain thermal barriers around personnel areas
-
-== Chemical Safety
-
-=== Electrolyte Handling
-* Use only approved chemicals and concentrations
-* Store chemicals according to manufacturer specifications
-* Provide appropriate spill containment and cleanup materials
-* Never mix incompatible chemicals
-
-=== Waste Disposal
-* Follow local regulations for chemical waste disposal
-* Neutralize electrolytes before disposal when required
-* Properly label and store waste materials
-* Maintain waste disposal records
-
-== Emergency Procedures
-
-=== Emergency Shutdown
-* Locate and test all emergency stop controls
-* Ensure emergency shutdown procedures are posted and understood
-* Provide multiple methods to de-energize the system
-* Train all operators on emergency procedures
-
-=== First Aid and Emergency Response
-* Maintain current first aid supplies appropriate for chemical and electrical hazards
-* Post emergency contact numbers prominently
-* Ensure fire extinguishers are appropriate for electrical and chemical fires
-* Provide emergency eyewash and shower facilities
-
-== Workspace Requirements
-
-=== Ventilation
-* Provide adequate ventilation to remove process gases and heat
-* Install gas detection systems where appropriate
-* Ensure makeup air is sufficient for safe operation
-* Regular testing and maintenance of ventilation systems
-
-=== Fire Prevention
-* Use appropriate fire suppression systems
-* Maintain clear egress paths
-* Store flammable materials safely
-* Regular inspection and testing of fire safety equipment
-
-== Training and Certification
-
-=== Required Training
-* Electrical safety training
-* Chemical handling certification
-* Emergency response procedures
-* Equipment-specific operation training
-
-=== Ongoing Requirements
-* Annual safety refresher training
-* Regular safety audits and inspections
-* Incident reporting and investigation procedures
-* Continuous improvement of safety procedures
-
-== Legal and Regulatory Compliance
-
-=== Applicable Standards
-* OSHA workplace safety requirements
-* National Electrical Code (NEC) compliance
-* Local building and safety codes
-* Environmental regulations
-
-=== Documentation Requirements
-* Maintain safety training records
-* Document all safety inspections
-* Keep current safety data sheets (SDS)
-* Regular review and update of safety procedures
-
-== Next Steps
-
-Only after thoroughly understanding and implementing all safety requirements should you proceed to xref:chamber-construction.adoc[Chamber Construction].
+. Ramp heaters down under control; avoid opening the hot zone until temperatures fall below 200 °C.
+. Keep ventilation running until oxygen evolution ceases and cold traps have warmed to safe handling temperature.
+. Lock out power sources before performing maintenance.
+. Dispose of or recycle collected condensates per local regulations.

--- a/modules/ROOT/pages/testing.adoc
+++ b/modules/ROOT/pages/testing.adoc
@@ -1,13 +1,24 @@
 = Testing & Calibration
 
-== Overview
+== Dry runs (Section 4.1)
 
-This chapter covers system testing, calibration procedures, and commissioning protocols.
+. Leak-check the assembled system with argon, targeting <50 sccm leakage at 50 mbar over ambient.
+. Heat-soak the hot zone to 1000 °C using an empty liner. Verify element balance, pyrometer agreement, and thermal uniformity before pushing to full process temperature.
+. Pump down the refining pot, engage the cold-trap with water/ice, and confirm condensation control and vacuum stability.
+. Exercise interlocks, emergency stops, and data logging while the system is at temperature to ensure safe recovery paths.
 
-== Coming Soon
+== Feed characterization (Section 4.2)
 
-Detailed testing procedures will be added in future revisions of this guide.
+. Sieve feedstock to ≤250 µm and bake at 150–200 °C to remove moisture and surface salts.
+. Perform a **LIBS** scan (190–900 nm) across representative samples to estimate oxide fractions (Fe-oxides, SiO₂, Al₂O₃, CaO, TiO₂, alkalis). Save the spectra with the batch record.
+. Compare measured composition to recipe limits. Adjust staging times or potentials if impurities run high.
 
-== Next Steps
+== Instrument calibration
 
-Proceed to xref:operation.adoc[Operation Manual] when testing is complete.
+* Validate pyrometers against a calibrated reference or high-temperature blackbody during the dry run.
+* Zero and span vacuum gauges (Pirani and capacitance manometer) using known pressure references.
+* Run the RGA under clean vacuum to establish baseline spectra before processing.
+
+== Readiness gate
+
+Proceed to xref:operation.adoc[Operation Manual] only after all dry-run criteria are met, feed characterization data is logged, and calibration records are stored.

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -1,13 +1,57 @@
 = Troubleshooting
 
-== Overview
+This chapter ties common symptoms to the v0.1 operating procedures. Use it alongside xref:operation.adoc[Operation Manual], xref:control-system.adoc[Control System], and xref:maintenance.adoc[Maintenance].
 
-This chapter covers common problems, diagnostic procedures, and corrective actions.
+== MOE stage issues
 
-== Coming Soon
+|===
+|Symptom|Likely cause|Corrective action (reference)
 
-Detailed troubleshooting guides will be added in future revisions of this guide.
+|Fe sump fails to accumulate
+|Cathodic overpotential too high or insufficient settling time
+|Return to the Fe window parameters (low current density ~0.2–0.4 A cm⁻²) and hold until OES Fe lines stabilize. Allow extra dwell before tapping.
 
-== Next Steps
+|Silicon alloying with iron
+|Fe sump temperature too high or Si stage ramp too aggressive
+|Lower sump temperature, reduce potential step to 10 %, and pause feeding until LIBS/OES indicates separation (Section 4.3).
 
-Proceed to xref:maintenance.adoc[Maintenance] for ongoing care procedures.
+|Excessive bubbling or spatter
+|Rapid feed rate or trapped gas pathways
+|Reduce feed rate, verify gas ports are clear, and ensure the argon blanket is within the 50–150 mbar range.
+|===
+
+== Vacuum refining problems
+
+|===
+|Symptom|Likely cause|Corrective action
+
+|RGA shows rising phosphorous despite hold
+|Insufficient temperature or pressure not reaching ≤10 Pa
+|Increase refining temperature toward 1800 °C and verify vacuum integrity using the dry-run leak criteria.
+
+|RGA spike at m/z ~44 (SiO)
+|Over-evaporation or cold-trap warming
+|Tighten cold-trap cooling, lower refining temperature slightly, and inspect trap fill level between runs (Section 4.4).
+|===
+
+== Casting defects
+
+|===
+|Symptom|Likely cause|Corrective action
+
+|Impurity bands through ingot
+|Cooling rate too fast or directional cooling disrupted
+|Reset casting ramp to 1–5 K min⁻¹ from bottom to top. Confirm mold coating is intact (Section 4.5).
+
+|Surface oxidation on poured ingot
+|Transfer exposure to air
+|Use a covered transfer crucible and minimize transit time from refining pot to mold.
+|===
+
+== Sensor anomalies
+
+* Pyrometers drifting: Recalibrate against reference per the testing chapter and check purge gas cleanliness.
+* LIBS/OES noise: Inspect optical windows for condensate buildup and realign fibers after cleaning.
+* Vacuum gauge disagreement: Re-zero Pirani and capacitance manometer, confirm gauge placement is per the utilities chapter.
+
+Document troubleshooting steps alongside batch records so recurring patterns can be addressed during scheduled maintenance.


### PR DESCRIPTION
## Summary
- Realign the preface and system overview with the v0.1 build manual targets and architecture
- Replace placeholder build, electrical, and control chapters with the detailed step-by-step instructions from the manual
- Update operations, safety, maintenance, troubleshooting, and appendix content to match the reference manual guidance

## Testing
- npm run build:site

------
https://chatgpt.com/codex/tasks/task_e_68c9a595aba48323a0bd8113a571d637