### PR TITLE
Replace binary assets with SVG equivalents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 build/
 dist/
+supplemental-ui/static/downloads/
 
 # Node.js dependencies
 node_modules/
@@ -22,3 +23,7 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+
+# Generated offline downloads
+modules/ROOT/assets/attachments/*.pdf
+modules/ROOT/assets/attachments/*.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+## Repository-wide guidelines
+- Do **not** commit binary artifacts (PDFs, ZIPs, etc.). Generate them during the build instead.
+- Offline download assets are produced by `scripts/build_offline_assets.py` and should remain untracked output.
+- The combined offline kit **must not** be packaged as a ZIP (leave the PDF/CSV as individual downloads).

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,7 +1,7 @@
 site:
   title: MOERC Build Guide
   start_page: moerc::preface.adoc
-  url: https://pierce403.github.io/moerc
+  url: https://moerc.org
 content:
   sources:
     - url: .
@@ -10,5 +10,6 @@ ui:
   bundle:
     url: https://raw.githubusercontent.com/pierce403/hackfables/b4ababf2660ea7e5fda930f5af076382fc0e9303/ui/ui-bundle.zip
     snapshot: true
+  supplemental_files: ./supplemental-ui
 output:
   dir: build/site

--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: moerc
 title: MOERC Build Guide
-version: ~
+version: '0.1'
 nav:
   - modules/ROOT/nav.adoc

--- a/modules/ROOT/assets/attachments/moerc-bom-v0.1.csv
+++ b/modules/ROOT/assets/attachments/moerc-bom-v0.1.csv
@@ -1,0 +1,16 @@
+Subsystem,Item,Quantity,Notes,Estimated Cost (USD)
+Hot-zone & Cell,High-temperature insulation kit,1,1700°C fiber boards/blanket panels and fasteners,350
+Hot-zone & Cell,Modular steel frame,1,80/20 extrusion or welded frame with hardware,250
+Hot-zone & Cell,Graphite heating elements,4,Custom machined elements rated to 1700°C,600
+Hot-zone & Cell,Type C thermocouple,2,Rhenium-tungsten probe with ceramic sheath,220
+Power & Distribution,25 kVA SCR power controller,1,Three-phase rated with phase-angle firing,1200
+Power & Distribution,Main fused disconnect,1,Lockable service entrance rated enclosure,150
+Power & Distribution,Step-down control transformer,1,Provides 120 VAC logic power,95
+Control & Instrumentation,Industrial controller or PLC,1,Supports PID loops and safety interlocks,180
+Control & Instrumentation,HMI touch panel,1,Minimum 7-inch display with Ethernet,250
+Control & Instrumentation,Sensor I/O modules,3,Digital and analog expansion modules,210
+Gas Handling,Mass flow controller,2,0-10 slpm argon-capable stainless unit,700
+Gas Handling,Inlet and exhaust valves,4,High-temperature pneumatic valves,180
+Ancillary Systems,Safety interlock switches,4,Door and service cover sensors,60
+Ancillary Systems,Cabling and harnessing,1,Includes high-temp leads and signal wiring,120
+Ancillary Systems,Fasteners and hardware kit,1,Stainless hardware assortment,65

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -10,3 +10,4 @@
 * xref:troubleshooting.adoc[Troubleshooting]
 * xref:maintenance.adoc[Maintenance]
 * xref:appendix.adoc[Appendix]
+* xref:downloads.adoc[Downloads]

--- a/modules/ROOT/pages/downloads.adoc
+++ b/modules/ROOT/pages/downloads.adoc
@@ -1,0 +1,23 @@
+= Downloads
+:description: Download the MOERC build manual and bill of materials for offline use.
+
+Looking for offline copies of the guide? Grab the curated files below. Each download bundles the latest v0.1 content from this
+site so you can reference it without an internet connection.
+
+== Quick links
+
+* link:/_/static/downloads/moerc-build-guide-v0.1.pdf["Build manual (PDF)",opts=download]
+* link:/_/static/downloads/moerc-bom-v0.1.csv["Bill of materials (CSV)",opts=download]
+
+== Need an all-in-one package?
+
+Project policy prohibits distributing binary ZIP archives directly from the repository, so we publish the PDF and CSV as
+individual downloads. To mirror the previous bundle locally, download both files above and archive them with your preferred
+tool:
+
+[,bash]
+----
+zip moerc-build-kit.zip moerc-build-guide-v0.1.pdf moerc-bom-v0.1.csv
+----
+
+Have suggestions for additional formats or automation? Open an issue via the link in the footer—we’d love to hear from you.

--- a/modules/ROOT/pages/overview.adoc
+++ b/modules/ROOT/pages/overview.adoc
@@ -1,4 +1,5 @@
 = System Overview
+:page-aliases: specs.adoc
 
 == At-a-glance
 

--- a/modules/ROOT/pages/sitemap.xml
+++ b/modules/ROOT/pages/sitemap.xml
@@ -1,0 +1,24 @@
+= Sitemap
+:page-layout: none
+:page-permalink: /sitemap.xml
+
+++++
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://moerc.org/</loc>
+  </url>
+  <url>
+    <loc>https://moerc.org/moerc/0.1/preface.html</loc>
+  </url>
+  <url>
+    <loc>https://moerc.org/moerc/0.1/overview.html</loc>
+  </url>
+  <url>
+    <loc>https://moerc.org/moerc/0.1/materials.html</loc>
+  </url>
+  <url>
+    <loc>https://moerc.org/moerc/0.1/downloads.html</loc>
+  </url>
+</urlset>
+++++

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "license": "CC0-1.0",
   "description": "Metal-Oxide Electrolysis Refinement Chamber Build Guide",
   "scripts": {
+    "prebuild:site": "scripts/build_offline_assets.py",
+    "build:downloads": "scripts/build_offline_assets.py",
     "build:site": "npx antora antora-playbook.yml",
     "preview": "npx http-server build/site -p 8080 -c-1",
     "clean": "rimraf build",

--- a/scripts/build_offline_assets.py
+++ b/scripts/build_offline_assets.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from typing import Iterable, List
+
+ROOT = Path(__file__).resolve().parent.parent
+MANUAL_MD = ROOT / "MOERC-Build-Manual-v0.1.md"
+ATTACHMENTS_DIR = ROOT / "modules/ROOT/assets/attachments"
+STATIC_DOWNLOADS_DIR = ROOT / "supplemental-ui/static/downloads"
+PDF_PATH = ATTACHMENTS_DIR / "moerc-build-guide-v0.1.pdf"
+BOM_CSV = ATTACHMENTS_DIR / "moerc-bom-v0.1.csv"
+
+PAGE_WIDTH = 612  # 8.5in at 72 dpi
+PAGE_HEIGHT = 792  # 11in at 72 dpi
+MARGIN_X = 54
+MARGIN_Y = 54
+LINE_HEIGHT = 14
+CHARS_PER_LINE = 90
+
+
+def ensure_output_dir() -> None:
+    ATTACHMENTS_DIR.mkdir(parents=True, exist_ok=True)
+    STATIC_DOWNLOADS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def strip_markdown(markdown_text: str) -> str:
+    text = markdown_text.replace("\r\n", "\n")
+    # Remove code fences
+    text = re.sub(r"```.*?```", lambda m: m.group(0).replace("`", ""), text, flags=re.S)
+    # Drop heading and blockquote markers
+    text = re.sub(r"^#{1,6}\s*", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^>\s?", "", text, flags=re.MULTILINE)
+    # Strip list markers
+    text = re.sub(r"^\s{0,3}[-*+]\s+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s{0,3}\d+\.\s+", "", text, flags=re.MULTILINE)
+    # Convert links and images
+    text = re.sub(r"!\[(.*?)\]\((.*?)\)", r"\1", text)
+    text = re.sub(r"\[(.*?)\]\((.*?)\)", r"\1", text)
+    # Strip emphasis markers
+    text = re.sub(r"[*_`]", "", text)
+    # Collapse multiple spaces
+    text = re.sub(r"[ \t]+", " ", text)
+    return text
+
+
+def convert_markdown_to_lines(markdown_path: Path) -> List[str]:
+    raw = markdown_path.read_text(encoding="utf-8")
+    stripped = strip_markdown(raw)
+    lines: List[str] = []
+    for line in stripped.splitlines():
+        line = line.rstrip()
+        if not line:
+            lines.append("")
+            continue
+        wrapped = wrap_text(line, CHARS_PER_LINE)
+        lines.extend(wrapped)
+    if not lines:
+        lines.append("")
+    return lines
+
+
+def wrap_text(text: str, width: int) -> List[str]:
+    words = text.split(" ")
+    wrapped: List[str] = []
+    current: List[str] = []
+    current_length = 0
+    for word in words:
+        if not current:
+            current = [word]
+            current_length = len(word)
+            continue
+        if current_length + 1 + len(word) <= width:
+            current.append(word)
+            current_length += 1 + len(word)
+        else:
+            wrapped.append(" ".join(current))
+            current = [word]
+            current_length = len(word)
+    if current:
+        wrapped.append(" ".join(current))
+    return wrapped
+
+
+def chunk_lines(lines: Iterable[str], per_page: int) -> List[List[str]]:
+    pages: List[List[str]] = []
+    current: List[str] = []
+    for line in lines:
+        current.append(line)
+        if len(current) >= per_page:
+            pages.append(current)
+            current = []
+    if current:
+        pages.append(current)
+    return pages or [[""]]
+
+
+def escape_pdf_text(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def build_content_stream(page_lines: List[str]) -> bytes:
+    start_y = PAGE_HEIGHT - MARGIN_Y
+    lines = ["BT", "/F1 12 Tf", f"{LINE_HEIGHT} TL", f"1 0 0 1 {MARGIN_X} {start_y} Tm"]
+    for line in page_lines:
+        if line:
+            lines.append(f"({escape_pdf_text(line)}) Tj")
+        lines.append("T*")
+    lines.append("ET")
+    payload = "\n".join(lines).encode("utf-8")
+    return f"<< /Length {len(payload)} >>\nstream\n".encode("utf-8") + payload + b"\nendstream"
+
+
+def write_pdf(lines: List[str], pdf_path: Path) -> None:
+    lines_per_page = max(1, int((PAGE_HEIGHT - 2 * MARGIN_Y) / LINE_HEIGHT))
+    pages = chunk_lines(lines, lines_per_page)
+
+    objects: List[bytes | None] = [None]
+
+    def new_object(data: bytes | None = None) -> int:
+        objects.append(data)
+        return len(objects) - 1
+
+    def set_object(index: int, data: bytes) -> None:
+        objects[index] = data
+
+    catalog_obj = new_object()
+    pages_obj = new_object()
+    font_obj = new_object(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+    page_entries: List[tuple[int, int]] = []
+    for page in pages:
+        content_obj = new_object(build_content_stream(page))
+        page_obj = new_object()
+        page_entries.append((page_obj, content_obj))
+
+    kids = " ".join(f"{page_obj} 0 R" for page_obj, _ in page_entries) or ""
+    set_object(pages_obj, f"<< /Type /Pages /Kids [{kids}] /Count {len(page_entries)} >>".encode("utf-8"))
+
+    for page_obj, content_obj in page_entries:
+        set_object(
+            page_obj,
+            f"<< /Type /Page /Parent {pages_obj} 0 R /MediaBox [0 0 {PAGE_WIDTH} {PAGE_HEIGHT}] /Resources << /Font << /F1 {font_obj} 0 R >> >> /Contents {content_obj} 0 R >>".encode(
+                "utf-8"
+            ),
+        )
+
+    set_object(catalog_obj, f"<< /Type /Catalog /Pages {pages_obj} 0 R >>".encode("utf-8"))
+
+    with pdf_path.open("wb") as fh:
+        fh.write(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+        offsets: List[int] = []
+        for index in range(1, len(objects)):
+            obj_data = objects[index]
+            if obj_data is None:
+                obj_data = b"<<>>"
+            offsets.append(fh.tell())
+            fh.write(f"{index} 0 obj\n".encode("utf-8"))
+            fh.write(obj_data)
+            fh.write(b"\nendobj\n")
+        xref_pos = fh.tell()
+        fh.write(f"xref\n0 {len(objects)}\n".encode("utf-8"))
+        fh.write(b"0000000000 65535 f \n")
+        for offset in offsets:
+            fh.write(f"{offset:010d} 00000 n \n".encode("utf-8"))
+        fh.write(b"trailer\n")
+        fh.write(f"<< /Size {len(objects)} /Root {catalog_obj} 0 R >>\n".encode("utf-8"))
+        fh.write(f"startxref\n{xref_pos}\n%%EOF".encode("utf-8"))
+
+
+def sync_static_downloads(files: Iterable[Path]) -> None:
+    for source in files:
+        if not source.exists():
+            raise FileNotFoundError(f"Missing offline asset: {source}")
+        destination = STATIC_DOWNLOADS_DIR / source.name
+        shutil.copy2(source, destination)
+
+
+def main() -> None:
+    ensure_output_dir()
+    lines = convert_markdown_to_lines(MANUAL_MD)
+    write_pdf(lines, PDF_PATH)
+    sync_static_downloads([PDF_PATH, BOM_CSV])
+
+
+if __name__ == "__main__":
+    main()

--- a/supplemental-ui/css/site-extra.css
+++ b/supplemental-ui/css/site-extra.css
@@ -1,0 +1,61 @@
+.header .navbar-item.button,
+.header .navbar-item .button {
+  font-weight: 600;
+}
+
+.header .navbar-item .button.is-primary {
+  background: #0060df;
+  border-color: #0051bd;
+}
+
+.header .navbar-item .button.is-primary:hover {
+  background: #0051bd;
+  border-color: #003f94;
+}
+
+.version-footer {
+  background: #0a0a0a;
+  color: #f0f0f0;
+  padding: 1.25rem 0;
+}
+
+.version-footer .version-badge {
+  display: inline-block;
+  margin-right: 0.5rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: #1d72b8;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.version-footer .repo-link {
+  color: #f0f6ff;
+  font-weight: 600;
+}
+
+.version-footer .repo-link:hover {
+  color: #abd4ff;
+}
+
+.version-footer .separator {
+  margin: 0 0.5rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.version-footer .footer-note {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+@media screen and (max-width: 1024px) {
+  body.toc2 #toc.toc2 {
+    display: none;
+  }
+  body.toc2 .doc {
+    margin-left: 0;
+  }
+  .navbar-menu {
+    padding: 0.75rem 1rem;
+  }
+}

--- a/supplemental-ui/partials/footer-content.hbs
+++ b/supplemental-ui/partials/footer-content.hbs
@@ -1,0 +1,14 @@
+<footer class="footer version-footer">
+  <div class="content has-text-centered">
+    {{#with page.componentVersion}}
+      {{#if ./displayVersion}}
+      <span class="version-badge">v{{./displayVersion}}</span>
+      {{else}}
+      <span class="version-badge">v{{./version}}</span>
+      {{/if}}
+    {{/with}}
+    <a class="repo-link" href="https://github.com/pierce403/moerc" target="_blank" rel="noopener">View source on GitHub</a>
+    <span class="separator" aria-hidden="true">•</span>
+    <span class="footer-note">Built with Antora</span>
+  </div>
+</footer>

--- a/supplemental-ui/partials/head-icons.hbs
+++ b/supplemental-ui/partials/head-icons.hbs
@@ -1,0 +1,2 @@
+    <link rel="icon" href="{{{relativize '/img/favicon.svg'}}}" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="{{{relativize '/img/favicon.svg'}}}">

--- a/supplemental-ui/partials/head-meta.hbs
+++ b/supplemental-ui/partials/head-meta.hbs
@@ -1,0 +1,16 @@
+    {{#with (or page.attributes.seo_description (or page.description 'Construction and operation guide for the Modular Open Electronics Research Cell (MOERC).'))}}
+    <meta name="description" content="{{this}}">
+    <meta property="og:description" content="{{this}}">
+    <meta name="twitter:description" content="{{this}}">
+    {{/with}}
+    <meta property="og:type" content="article">
+    {{#with page.title}}
+    <meta property="og:title" content="{{this}}">
+    <meta name="twitter:title" content="{{this}}">
+    {{/with}}
+    {{#with (or page.canonicalUrl site.url)}}
+    <meta property="og:url" content="{{this}}">
+    {{/with}}
+    <meta property="og:image" content="{{{relativize '/img/moerc-social-card.svg'}}}">
+    <meta name="twitter:image" content="{{{relativize '/img/moerc-social-card.svg'}}}">
+    <meta name="twitter:card" content="summary_large_image">

--- a/supplemental-ui/partials/head-styles.hbs
+++ b/supplemental-ui/partials/head-styles.hbs
@@ -1,0 +1,2 @@
+    <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
+    <link rel="stylesheet" href="{{{uiRootPath}}}/css/site-extra.css">

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -1,0 +1,34 @@
+<header class="header">
+  <nav class="navbar">
+    <div class="navbar-brand">
+      <a class="navbar-item" href="{{{or site.url siteRootPath}}}">{{site.title}}</a>
+      {{#if env.SITE_SEARCH_PROVIDER}}
+      <div class="navbar-item search hide-for-print">
+        <div id="search-field" class="field">
+          <input id="search-input" type="text" placeholder="Search the docs"{{#if page.home}} autofocus{{/if}}>
+        </div>
+      </div>
+      {{/if}}
+      <button class="navbar-burger" aria-controls="topbar-nav" aria-expanded="false" aria-label="Toggle main menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+    </div>
+    <div id="topbar-nav" class="navbar-menu">
+      <div class="navbar-end">
+        <a class="navbar-item" href="{{{relativize '/moerc/0.1/preface.html'}}}">Guide</a>
+        <a class="navbar-item" href="{{{relativize '/moerc/0.1/overview.html'}}}">Specs</a>
+        <a class="navbar-item" href="{{{relativize '/moerc/0.1/downloads.html'}}}">Downloads</a>
+        <a class="navbar-item" href="https://github.com/pierce403/moerc" target="_blank" rel="noopener">Repo</a>
+        <div class="navbar-item">
+          <span class="control">
+            <a class="button is-primary" href="{{{relativize '/_/static/downloads/moerc-build-guide-v0.1.pdf'}}}" download>
+              Download
+            </a>
+          </span>
+        </div>
+      </div>
+    </div>
+  </nav>
+</header>

--- a/supplemental-ui/static/img/favicon.svg
+++ b/supplemental-ui/static/img/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#003366"/>
+  <path d="M18 46h28L32 18z" fill="#00c2ff"/>
+</svg>

--- a/supplemental-ui/static/img/moerc-social-card.svg
+++ b/supplemental-ui/static/img/moerc-social-card.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">MOERC Guide</title>
+  <desc id="desc">Social preview card for the Modular Open Electronics Research Cell documentation.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#021a33"/>
+      <stop offset="100%" stop-color="#054f88"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" rx="24"/>
+  <g fill="#ffffff" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">
+    <text x="80" y="210" font-size="64" font-weight="700">Modular Open Electronics</text>
+    <text x="80" y="290" font-size="64" font-weight="700">Research Cell</text>
+    <text x="80" y="380" font-size="40" opacity="0.85">Assembly &amp; Operations Guide</text>
+  </g>
+  <g transform="translate(900 160)">
+    <rect x="0" y="0" width="200" height="200" rx="40" fill="rgba(255,255,255,0.14)"/>
+    <path d="M60 150h80L100 50z" fill="#6ee0ff"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- remove committed binary favicon and social preview images to resolve "Binary files are not supported" errors
- replace the UI metadata hooks to reference new SVG favicon and Open Graph artwork
- tidy the .gitignore entry for generated offline archives so build outputs stay untracked

## Testing
- `npm run build:site`


------
https://chatgpt.com/codex/tasks/task_e_68cb4668329483238330e61cbc990232